### PR TITLE
Show equation being plotted

### DIFF
--- a/_posts/2017-12-15-polynomial-roots-toy.md
+++ b/_posts/2017-12-15-polynomial-roots-toy.md
@@ -46,6 +46,10 @@ Grab the red dots and play around! Or jump to the
 <input type="number" name="degView" id="degView" class="myDegInput" min="1" max="7" step="1" value="4">
 </form>
 
+<b>Equation:</b>
+<div id="equationBox" class="myLabel" style="">
+</div>
+
 <!------------------------------------------------------------>
 <!-- CODE -->
 

--- a/_posts/2017-12-15-polynomial-roots-toy.md
+++ b/_posts/2017-12-15-polynomial-roots-toy.md
@@ -46,9 +46,8 @@ Grab the red dots and play around! Or jump to the
 <input type="number" name="degView" id="degView" class="myDegInput" min="1" max="7" step="1" value="4">
 </form>
 
-<b>Equation:</b>
-<div id="equationBox" class="myLabel" style="">
-</div>
+<label for="equationTextBox" class="myLabel">Equation (generated from degree):</label>
+<input type="text" id="equationTextBox" width="30" disabled>
 
 <!------------------------------------------------------------>
 <!-- CODE -->

--- a/assets/js/poly-root-toy.js
+++ b/assets/js/poly-root-toy.js
@@ -210,10 +210,8 @@
       }
       // The higest-degree term has a coefficient of 1.
       formula_pieces.push("x^" + this.degree);
-      document.getElementById('equationBox').innerHTML = formula_pieces.join(" + ");
-      // TODO: Use escaping and the try toLatex();
-      // If we want to show the actual formula with coefficients, it's easy but ugly:
-      // document.getElementById('equationBox').innerHTML = this.p.toString();
+      document.getElementById('equationTextBox').value =
+        formula_pieces.join(" + ") + " = 0";
     },
 
     'updatePolyCoeffsFromRoots': function() {

--- a/assets/js/poly-root-toy.js
+++ b/assets/js/poly-root-toy.js
@@ -200,6 +200,20 @@
     'showingDiscRoots': false,
     'discRootPoints': [],
 
+    'updateEquation': function() {
+      var formula_pieces = [];
+      // Lower degrees have a coefficient ai.
+      for (var i = 0; i < this.degree; i++) {
+        formula_pieces.push("a" + i + " x^" + i);
+      }
+      // The higest-degree term has a coefficient of 1.
+      formula_pieces.push("x^" + this.degree);
+      document.getElementById('equationBox').innerHTML = formula_pieces.join(" + ");
+      // TODO: Use escaping and the try toLatex();
+      // If we want to show the actual formula with coefficients, it's easy but ugly:
+      // document.getElementById('equationBox').innerHTML = this.p.toString();
+    },
+
     'updatePolyCoeffsFromRoots': function() {
       this.degree = this.roots.length;
       this.p = Polynomial.fromRoots(this.roots);
@@ -327,6 +341,7 @@
 
             controller.updateRootView();
             controller.updateCoeffView();
+            controller.updateEquation();
           };
         })(this);
     },

--- a/assets/js/poly-root-toy.js
+++ b/assets/js/poly-root-toy.js
@@ -202,8 +202,10 @@
 
     'updateEquation': function() {
       var formula_pieces = [];
-      // Lower degrees have a coefficient ai.
-      for (var i = 0; i < this.degree; i++) {
+      // Degree zero is just the coefficient.
+      formula_pieces.push("a0");
+      // Lower degrees have a coefficient ai and x^i.
+      for (var i = 1; i < this.degree; i++) {
         formula_pieces.push("a" + i + " x^" + i);
       }
       // The higest-degree term has a coefficient of 1.


### PR DESCRIPTION
Right below the degree text box,  added a new textbox that is disabled (uneditedable) with the equation actually being plotted, based on the degree.  For example
degree  equation
1             a0 + x^1 = 0
2            a0 + a1 x^1 + x^2 = 0
3            a0 + a1 x^1 + a2 x^2 + x^3 = 0

I had the idea to add the equation because I was confused.  The coefficient labels on the plot did not obviously match the equation at the top of the "Explanation" section-- e.g. for degree n there is no a_n-- so I thought there was a mistake.

<img width="892" alt="Screen Shot 2019-05-23 at 8 29 06 PM" src="https://user-images.githubusercontent.com/4942878/58298015-8835a580-7d9f-11e9-8474-9f8953ed135d.png">
