### PR TITLE
Show equation being plotted with Latex

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,7 +1,10 @@
 <!-- start custom head snippets -->
 <script type="text/x-mathjax-config">
 MathJax.Hub.Config({
-  TeX: { equationNumbers: { autoNumber: "AMS" } }
+  TeX: { equationNumbers: { autoNumber: "AMS" } },
+  CommonHTML: { linebreaks: { automatic: true } },
+  "HTML-CSS": { linebreaks: { automatic: true } },
+         SVG: { linebreaks: { automatic: true } }
 });
 </script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"></script>

--- a/_posts/2017-12-15-polynomial-roots-toy.md
+++ b/_posts/2017-12-15-polynomial-roots-toy.md
@@ -20,9 +20,8 @@ margin-bottom: 1em;
 display: inline-block;
 }
 
-/* Setting height prevents height changing during re-rendering. */
 .myOutputEquation {
-height: 40px;
+min-height: 40px;
 text-align: center;
 }
 

--- a/_posts/2017-12-15-polynomial-roots-toy.md
+++ b/_posts/2017-12-15-polynomial-roots-toy.md
@@ -20,6 +20,12 @@ margin-bottom: 1em;
 display: inline-block;
 }
 
+/* Setting height prevents height changing during re-rendering. */
+.myOutputEquation {
+height: 40px;
+text-align: center;
+}
+
 .myDegInput {
 width: 4em;
 }
@@ -41,6 +47,11 @@ Grab the red dots and play around! Or jump to the
 </div>
 <div id="rootbox" class="jxgbox mybox" style="">
 </div>
+
+<div id="equationBox" class="jxgbox myOutputEquation">
+\({a_0 + a_1 x + a_2 x^2 + a_3 x^3 + x^4 = 0}\)
+</div>
+<br>
 
 <form onsubmit="return false;">
 <div>

--- a/assets/js/poly-root-toy.js
+++ b/assets/js/poly-root-toy.js
@@ -233,6 +233,52 @@
     this.degreeInput.oninput();
   };
 
+  /*
+   * Return a string for the X term of that degree.  Usually this returns
+   * "x^degree" but 0 and 1 are special cases.
+   */
+  function buildXTermStr(degree) {
+    if (degree == 0) {
+      // Degree zero is just the coefficient-- no x term.
+      return "";
+    } else if (degree == 1) {
+      // Degree one does not need an exponent (x^1 is redundant).
+      return "x";
+    }
+    return "x^" + degree;
+  }
+
+  /*
+   * Return a string with a polynomial equation up to degree.  Examples:
+   * degree  equation
+   * 1       a0 + x = 0
+   * 2       a0 + a1 x + x^2 = 0
+   * 3       a0 + a1 x + a2 x^2 + x^3 = 0
+   */
+  function buildEquationStr(degree) {
+    var formula_pieces = [];
+    // Generate equation up to (but not including) degree.
+    for (var i = 0; i < degree; i++) {
+      formula_pieces.push("a_" + i + buildXTermStr(i));
+    }
+    // The higest-degree term has a coefficient of 1.
+    formula_pieces.push(buildXTermStr(degree));
+    return formula_pieces.join(" + ") + " = 0";
+  }
+
+  function buildEquationStrOld(degree) {
+    var formula_pieces = [];
+    // Degree zero is just the coefficient.
+    formula_pieces.push("a_0");
+    // Lower degrees have a coefficient ai and x^i.
+    for (var i = 1; i < degree; i++) {
+      formula_pieces.push("a_" + i + " x^" + i);
+    }
+    // The higest-degree term has a coefficient of 1.
+    formula_pieces.push("x^" + degree);
+    return formula_pieces.join(" + ") + " = 0";
+  }
+
   PolyRootController.prototype = {
     'degree': 0,
     'degreeInput': {},
@@ -252,7 +298,16 @@
     'showingDiscRoots': false,
     'discRootPoints': [],
 
-    'updatePolyCoeffsFromRoots': function() {
+   'updateEquation': function() {
+      var math = MathJax.Hub.getAllJax('equationBox')[0];
+      // Make sure MathJax is ready to do stuff.
+      if ( math != null) {
+        var equation = buildEquationStr(this.degree);
+        MathJax.Hub.Queue(["Text",math,equation]);
+      }
+   },    
+
+   'updatePolyCoeffsFromRoots': function() {
       this.degree = this.roots.length;
       this.p = Polynomial.fromRoots(this.roots);
       this.coeffs = this.p.coeffArray();
@@ -371,6 +426,7 @@
             controller.teardownPoints();
 
             controller.setDegreeFromView();
+            controller.updateEquation();
 
             controller.setupRandomRoots();
             controller.updatePolyCoeffsFromRoots();

--- a/assets/js/poly-root-toy.js
+++ b/assets/js/poly-root-toy.js
@@ -245,7 +245,14 @@
       // Degree one does not need an exponent (x^1 is redundant).
       return "x";
     }
-    return "x^" + degree;
+    return "x^" + wrap(degree);
+  }
+
+  /*
+   * Wraps the value in a string of enclosing curly braces.  E.g. wrap(10) returns "{10}".
+   */
+  function wrap(value) {
+    return "{" + value + "}";
   }
 
   /*
@@ -259,7 +266,7 @@
     var formula_pieces = [];
     // Generate equation up to (but not including) degree.
     for (var i = 0; i < degree; i++) {
-      formula_pieces.push("a_" + i + buildXTermStr(i));
+      formula_pieces.push("a_" + wrap(i) + buildXTermStr(i));
     }
     // The higest-degree term has a coefficient of 1.
     formula_pieces.push(buildXTermStr(degree));


### PR DESCRIPTION
Between the plots and the degree input, there is now another jxgbox-class styled box with a LateX (MathJax-rendered) version of the equation.

For example:
degree...equation
1.............a0 + x = 0
2.............a0 + a1 x + x^2 = 0
3.............a0 + a1 x + a2 x^2 + x^3 = 0

There is sometimes a noticeable delay in rendering (at least when serving locally).

I had the idea to add the equation because I was confused. The coefficient labels on the plot did not obviously match the equation at the top of the "Explanation" section-- e.g. for degree n there is no a_n-- so I thought there was a mistake.


<img width="809" alt="Screen Shot 2019-07-11 at 7 44 22 PM" src="https://user-images.githubusercontent.com/4942878/61094818-660eea00-a416-11e9-9be7-fcbe6d0762a2.png">